### PR TITLE
Indicate that Bitcoin Core can be used, not only Bitcoin Knots

### DIFF
--- a/Dumplings/Helpers/KnotsStatus.cs
+++ b/Dumplings/Helpers/KnotsStatus.cs
@@ -6,21 +6,21 @@ using System.Threading.Tasks;
 
 namespace Dumplings.Helpers
 {
-    public static class KnotsStatus
+    public static class BitcoinStatus
     {
         public static async Task CheckAsync(RPCClient client)
         {
-            Logger.LogInfo("Checking Bitcoin Knots sync status...");
+            Logger.LogInfo("Checking Bitcoin sync status...");
 
             var bci = await client.GetBlockchainInfoAsync();
 
             var missingBlocks = bci.Headers - bci.Blocks;
             if (missingBlocks != 0)
             {
-                throw new InvalidOperationException($"Knots is not synchronized. Blocks missing: {missingBlocks}.");
+                throw new InvalidOperationException($"Bitcoin is not synchronized. Blocks missing: {missingBlocks}.");
             }
 
-            Logger.LogInfo($"Bitcoin Knots is synchronized. Current height: {bci.Blocks}.");
+            Logger.LogInfo($"Bitcoin is synchronized. Current height: {bci.Blocks}.");
         }
     }
 }

--- a/Dumplings/Scanning/Scanner.cs
+++ b/Dumplings/Scanning/Scanner.cs
@@ -20,7 +20,7 @@ namespace Dumplings.Scanning
         {
             Rpc = rpc;
             Directory.CreateDirectory(WorkFolder);
-            KnotsStatus.CheckAsync(rpc).GetAwaiter().GetResult();
+            BitcoinStatus.CheckAsync(rpc).GetAwaiter().GetResult();
         }
 
         //public const string WorkFolder = @"C:\Users\user\source\repos\Dumplings\Dumplings.Cli\bin\Release\netcoreapp3.1\Scanner";

--- a/Dumplings/Stats/Statista.cs
+++ b/Dumplings/Stats/Statista.cs
@@ -535,7 +535,7 @@ namespace Dumplings.Stats
 
         private Dictionary<YearMonth, Money> CalculateNeverMixed(RPCClient rpc, IEnumerable<VerboseTransactionInfo> coinJoins)
         {
-            KnotsStatus.CheckAsync(rpc).GetAwaiter().GetResult();
+            BitcoinStatus.CheckAsync(rpc).GetAwaiter().GetResult();
             // Go through all the coinjoins.
             // If a change output is spent and didn't go to coinjoins, then it didn't get remixed.
             var coinJoinInputs =
@@ -590,7 +590,7 @@ namespace Dumplings.Stats
 
         private Dictionary<YearMonth, Money> CalculateNeverMixedFromTx0s(RPCClient rpc, IEnumerable<VerboseTransactionInfo> samuriCjs, IEnumerable<VerboseTransactionInfo> samuriTx0s)
         {
-            KnotsStatus.CheckAsync(rpc).GetAwaiter().GetResult();
+            BitcoinStatus.CheckAsync(rpc).GetAwaiter().GetResult();
 
             // Go through all the outputs of TX0 transactions.
             // If an output is spent and didn't go to coinjoins or other TX0s, then it didn't get remixed.

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 1. Get Git: https://git-scm.com/downloads
 1. Get .NET Core SDK: https://www.microsoft.com/net/download
-1. Get Bitcoin Knots: https://bitcoinknots.org/
+1. Get Bitcoin Core: https://bitcoincore.org/ or Bitcoin Knots: https://bitcoinknots.org/
 1. Make sure your bitcoin.conf has the following entries: `txindex = 1`, `server = 1`, `rpcuser = user`, `rpcpassword = password`, `listen = 1`, `rpcworkqueue = 128`
-1. Run Knots and wait until it's synchronized.
+1. Run Bitcoin and wait until it's synchronized.
 1. `git clone https://github.com/nopara73/Dumplings.git`
 1. `cd Dumplings/Dumplings.Cli`
 1. `dotnet run -- sync --rpcuser=user --rpcpassword=password`
 
 # Usage
 
-1. Run Knots, wait until it's synchronized.
+1. Run Bitcoin, wait until it's synchronized.
 1. `cd Dumplings/Dumplings.Cli`
 
 ## 1. Synchronization


### PR DESCRIPTION
Required getblock verbosity 3 was introduced in Bitcoin Core 23.0

Fixes https://github.com/nopara73/Dumplings/issues/7
Obsoletes https://github.com/nopara73/Dumplings/pull/8